### PR TITLE
extensions and user-data path corrected

### DIFF
--- a/VSCodePortable/App/AppInfo/Launcher/VSCodePortable.ini
+++ b/VSCodePortable/App/AppInfo/Launcher/VSCodePortable.ini
@@ -1,7 +1,7 @@
 [Launch]
 ProgramExecutable=VSCode\code.exe
 ProgramExecutable64=VSCode64\code.exe
-CommandLineArguments='--user-data-dir="%PAL:DataDir%\code" --extensions-dir="%PAL:DataDir%\extensions"'
+CommandLineArguments='--user-data-dir="%PAL:DataDir%\user-data" --extensions-dir="%PAL:DataDir%\extensions"'
 DirectoryMoveOK=yes
 DisableSplashScreen=true
 SplashTime=0

--- a/VSCodePortable/App/AppInfo/Launcher/VSCodePortable.ini
+++ b/VSCodePortable/App/AppInfo/Launcher/VSCodePortable.ini
@@ -1,7 +1,7 @@
 [Launch]
 ProgramExecutable=VSCode\code.exe
 ProgramExecutable64=VSCode64\code.exe
-CommandLineArguments='--user-data-dir="%PAL:DataDir%\code" --extensions-dir="%PAL:DataDir%\code\extensions"'
+CommandLineArguments='--user-data-dir="%PAL:DataDir%\code" --extensions-dir="%PAL:DataDir%\extensions"'
 DirectoryMoveOK=yes
 DisableSplashScreen=true
 SplashTime=0


### PR DESCRIPTION
Now is works like "https://code.visualstudio.com/docs/editor/portable" describes the portable mode.